### PR TITLE
Added Markdown support in speaker, event, member details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7827,6 +7827,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "core-js": "^3.6.4",
     "firebase": "^7.14.0",
+    "marked": "^0.8.2",
     "register-service-worker": "^1.6.2",
     "v-offline": "^1.2.1",
     "vue": "^2.6.11",

--- a/src/components/speakers/SpeakerDesktop.vue
+++ b/src/components/speakers/SpeakerDesktop.vue
@@ -60,7 +60,7 @@
               <v-card>
                 <v-card-title class="google-font">About:</v-card-title>
                 <v-card-text>
-                  <p class="google-font" style="font-size:90%">{{speaker.bio}}</p>
+                  <p class="google-font" style="font-size:90%" v-html="marked(speaker.bio)">{{speaker.bio}}</p>
                 </v-card-text>
               </v-card>
             </v-col>

--- a/src/components/speakers/SpeakerMobile.vue
+++ b/src/components/speakers/SpeakerMobile.vue
@@ -47,7 +47,7 @@
               <SocialMediaDetails :data="speaker.socialLinks" />
             </v-col>
             <v-col class="pa-2" cols="12" sm="8">
-              <p class="google-font my-4" style="font-size:110%">{{speaker.bio}}</p>
+              <p class="google-font my-4" style="font-size:110%" v-html="marked(speaker.bio)">{{speaker.bio}}</p>
             </v-col>
           </v-row>
         </v-container>

--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,15 @@ import store from './store'
 import vuetify from './plugins/vuetify';
 import generalFunctions from './functions/generalFunctions'
 import './style.css'
+import marked from 'marked';
 
+Vue.mixin({
+  methods: {
+    marked: function(input) {
+      return marked(input);
+    }
+  }
+});
 
 
 

--- a/src/views/Events/layout/sublayout/LayoutAbout.vue
+++ b/src/views/Events/layout/sublayout/LayoutAbout.vue
@@ -5,7 +5,7 @@
                 <v-row class="">
                     <v-col>
                         <h1 class="google-font">{{data.name}} Details</h1>
-                        <p class="google-font mb-3">{{data.des}}</p>
+                        <p class="google-font mb-3" v-html="marked(data.des)">{{data.des}}</p>
 
                         <span v-for="(item,i) in data.hashtags" :key="i">
                             <v-chip class="mr-1" :href="'https://twitter.com/hashtag/'+item" target="_blank" label small>#{{item}}</v-chip>

--- a/src/views/Team/TeamDetails.vue
+++ b/src/views/Team/TeamDetails.vue
@@ -50,7 +50,7 @@
                             </v-col>
                             <v-col md="9" lg="9" sm="8" cols="12">
                                     <p class="mb-0"><b>Bio</b></p>
-                                    <p class="mt-1 mb-0 google-font mt-0" style="font-size:110%">{{MemberDetails.bio}}</p>
+                                    <p class="mt-1 mb-0 google-font mt-0" style="font-size:110%" v-html="marked(MemberDetails.bio)">{{MemberDetails.bio}}</p>
 
                                     <p class="mb-0 mt-3"><b>Social Links</b></p>
                                     <p class="mt-1 mb-0 google-font mt-0" style="font-size:110%">


### PR DESCRIPTION
It is now possible to add markdown content in speaker, event and team details.

The `marked` library as a mixin and `v-html` bindings were used.